### PR TITLE
[#13] 비밀번호 재설정 페이지 추가

### DIFF
--- a/src/pages/ResetPasswordPage.tsx
+++ b/src/pages/ResetPasswordPage.tsx
@@ -12,7 +12,7 @@ const ResetPasswordPage = () => {
     setIsLoading(true);
 
     const res = await fetch(
-      'https://qpftupbuhjmkksxkivwi.supabase.co/functions/v1/reset-password',
+      `${import.meta.env.VITE_SUPABASE_URL}/functions/v1/reset-password`,
       {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },

--- a/src/pages/ResetPasswordPage.tsx
+++ b/src/pages/ResetPasswordPage.tsx
@@ -1,0 +1,138 @@
+import { useEffect, useState } from 'react';
+import styled from 'styled-components';
+import { BoldText, FlexBox, RegularText } from '../components/atoms';
+import { theme } from '../styles/theme';
+
+const ResetPasswordPage = () => {
+  const [email, setEmail] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+  const [toastMessage, setToastMessage] = useState('');
+
+  const handleReset = async () => {
+    setIsLoading(true);
+
+    const res = await fetch(
+      'https://qpftupbuhjmkksxkivwi.supabase.co/functions/v1/reset-password',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email }),
+      },
+    );
+
+    const result = await res.json();
+
+    setIsLoading(false);
+
+    if (!res.ok) {
+      setToastMessage(result.error || '실패했습니다.');
+      setEmail('');
+    } else {
+      setToastMessage('메일을 발송했습니다!');
+    }
+  };
+
+  useEffect(() => {
+    if (toastMessage) {
+      const timeout = setTimeout(() => setToastMessage(''), 2000);
+      return () => clearTimeout(timeout);
+    }
+  }, [toastMessage]);
+
+  return (
+    <Container>
+      <BoldText
+        size={28}
+        color={theme.color.gray.gray800}
+        style={{ marginBottom: '0.4rem' }}
+      >
+        가입하신 이메일 주소를
+        <br /> 입력해주세요
+      </BoldText>
+      <RegularText
+        size={16}
+        color={theme.color.gray.gray500}
+        style={{ marginBottom: '1.6rem' }}
+      >
+        이메일 주소로 임시 비밀번호를 보내드려요.
+      </RegularText>
+      <Label>이메일</Label>
+      <Input
+        type="email"
+        placeholder="이메일을 입력해주세요"
+        value={email}
+        onChange={(e) => {
+          setEmail(e.target.value);
+        }}
+      />
+      <FlexBox col fullWidth gap="0.8rem" style={{ marginTop: 'auto' }}>
+        {toastMessage && <Toast>{toastMessage}</Toast>}
+        <Button disabled={!email || isLoading} onClick={handleReset}>
+          새로운 비밀번호 전송
+        </Button>
+        <ReturnLoginButton onClick={() => history.back()}>
+          로그인으로 돌아가기
+        </ReturnLoginButton>
+      </FlexBox>
+    </Container>
+  );
+};
+
+export default ResetPasswordPage;
+
+const Container = styled.div`
+  padding: 3.4rem 1.4rem;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+`;
+
+const Label = styled.label`
+  display: block;
+  ${({ theme }) => theme.font.bold14}
+  color: ${theme.color.brand.main};
+  margin-bottom: 0.8rem;
+`;
+
+const Input = styled.input`
+  width: 100%;
+  padding: 1.1rem 1.4rem;
+  ${({ theme }) => theme.font.regular16}
+  border: 1px solid
+    ${({ theme }) => theme.color.gray.gray200};
+  border-radius: 0.8rem;
+  &:focus {
+    border-color: ${theme.color.brand.main};
+  }
+`;
+
+const Button = styled.button<{ disabled?: boolean }>`
+  width: 100%;
+  height: 4.8rem;
+  border-radius: 0.8rem;
+  background-color: ${({ disabled, theme }) =>
+    disabled ? theme.color.gray.gray50 : theme.color.brand.main};
+  color: ${({ disabled, theme }) =>
+    disabled ? theme.color.gray.gray400 : 'white'};
+  ${({ theme }) => theme.font.semibold16};
+`;
+
+const ReturnLoginButton = styled.button`
+  width: 100%;
+  height: 4.8rem;
+  border-radius: 0.8rem;
+  ${({ theme }) => theme.font.semibold16}
+  color: ${({ theme }) => theme.color.gray.gray200};
+  border: 1px solid ${({ theme }) => theme.color.gray.gray100};
+`;
+
+const Toast = styled.div`
+  position: relative;
+  width: 100%;
+  height: 5.2rem;
+  ${({ theme }) => theme.font.regular14};
+  background-color: black;
+  color: #fff;
+  padding: 1.5rem 1.4rem;
+  border-radius: 0.8rem;
+`;

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -7,6 +7,7 @@ import SignUpVerifyPage from './SignUpVerifyPage';
 import WelcomePage from './WelcomePage';
 import LoginPage from './LoginPage';
 import AuthCallbackPage from './AuthCallbackPage';
+import ResetPasswordPage from './ResetPasswordPage';
 
 export {
   HomePage,
@@ -18,4 +19,5 @@ export {
   WelcomePage,
   LoginPage,
   AuthCallbackPage,
+  ResetPasswordPage,
 };

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -4,6 +4,7 @@ import {
   HomePage,
   LoginPage,
   OnboardingPage,
+  ResetPasswordPage,
   SignUpEmailPage,
   SignUpPasswordPage,
   SignUpVerifyPage,
@@ -52,6 +53,10 @@ export const router = createBrowserRouter([
       {
         path: '/auth/callback',
         element: <AuthCallbackPage />,
+      },
+      {
+        path: '/reset-password',
+        element: <ResetPasswordPage />,
       },
     ],
   },

--- a/src/supabase/functions/README.md
+++ b/src/supabase/functions/README.md
@@ -1,0 +1,1 @@
+# 단순 Edge Functions 코드 저장용

--- a/src/supabase/functions/reset-password.js
+++ b/src/supabase/functions/reset-password.js
@@ -1,0 +1,114 @@
+import { serve } from 'https://deno.land/std@0.203.0/http/server.ts';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.39.7';
+const resendKey = Deno.env.get('RESEND_API_KEY');
+const supabaseUrl = Deno.env.get('SUPABASE_URL');
+const serviceRoleKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY');
+function generateSecurePassword() {
+  const chars =
+    'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$%^&*';
+  return Array.from(
+    {
+      length: 10,
+    },
+    () => chars[Math.floor(Math.random() * chars.length)],
+  ).join('');
+}
+serve(async (req) => {
+  // ✅ CORS 처리
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', {
+      headers: corsHeaders(),
+    });
+  }
+  try {
+    const { email } = await req.json();
+    console.log('요청받은 email: ', email);
+    // ✅ Supabase client 생성
+    const supabase = createClient(supabaseUrl, serviceRoleKey);
+    // ✅ 임시 비밀번호 생성
+    const tempPassword = generateSecurePassword();
+    // ✅ 전체 사용자 조회
+    const {
+      data: { users },
+      error: fetchError,
+    } = await supabase.auth.admin.listUsers();
+    if (fetchError || !users?.length) {
+      return responseJSON(500, {
+        error: '전체 유저 조회 실패',
+      });
+    }
+    // ✅ 해당 사용자 조회
+    const user = users.find((u) => u.email === email);
+    if (!user) {
+      return responseJSON(404, {
+        error: `이메일 ${email} 유저 없음`,
+      });
+    }
+    console.log(user);
+    // ✅ 비밀번호 업데이트
+    const { error: updateError } = await supabase.auth.admin.updateUserById(
+      user.id,
+      {
+        password: tempPassword,
+      },
+    );
+    if (updateError) {
+      return responseJSON(500, {
+        error: '비밀번호 변경 실패',
+      });
+    }
+    // ✅ Resend API 호출
+    const emailRes = await fetch('https://api.resend.com/emails', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${resendKey}`,
+      },
+      body: JSON.stringify({
+        from: 'NutritionCorp <no-reply@nutritioncorp.kr>',
+        to: email,
+        subject: '임시 비밀번호 안내',
+        html: `
+          <p>안녕하세요!</p>
+          <p>요청하신 임시 비밀번호는 아래와 같습니다:</p>
+          <p><strong>${tempPassword}</strong></p>
+          <p>로그인 후 꼭 비밀번호를 변경해주세요.</p>
+        `,
+      }),
+    });
+    const emailData = await emailRes.json();
+    if (!emailRes.ok) {
+      return responseJSON(500, {
+        error: '이메일 발송 실패',
+        detail: emailData,
+      });
+    }
+    return responseJSON(200, {
+      success: true,
+      emailData,
+    });
+  } catch (err) {
+    return responseJSON(500, {
+      error: '서버 내부 오류 발생',
+      detail: err.message || err,
+    });
+  }
+});
+// ✅ 공통 응답 헤더 (CORS 허용)
+function corsHeaders() {
+  return {
+    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Methods': 'POST, OPTIONS',
+    'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+  };
+}
+// ✅ 공통 JSON 응답 포맷
+function responseJSON(status, data) {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: {
+      'Content-Type': 'application/json',
+      ...corsHeaders(),
+    },
+  });
+}


### PR DESCRIPTION
> Close #13 

## 사진
<img width="581" height="407" alt="image" src="https://github.com/user-attachments/assets/df271a35-ac5d-4e90-9df2-a1ff6c0f088e" />

## 커밋 리스트

#### ✅ feat: 비밀번호 재설정 api 구현

- 사용자에게 임시 비밀번호 메일로 제공
- auth Table에 있는 유저 패스워드 변경

#### ✅ feat: 비밀번호 재설정 페이지 구현

- 비밀번호 재설정 api 연동


